### PR TITLE
Make XMPP URI field read-only

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <noscript><h3>You need JavaScript to follow the invitation.</h3></noscript>
     <h3 class="text-center" id="heading"></h3>
     <p class="text-center"><a class="btn btn-primary" id="button"></a></p>
-    <input type="url" class="form-control text-center" id="url_in"></input>
+    <input type="url" class="form-control text-center" id="url_in" readonly></input>
     <p class="lead text-center" id="clients"></p>
     <p class="lead" id="recommend"></p>
 


### PR DESCRIPTION
As currently there is no way to set new XMPP URI making
this field read-only avoids UX issues.

Fixes #7