### PR TITLE
Autodiscover preferred browser language, enhances #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.js

--- a/config.js.dist
+++ b/config.js.dist
@@ -1,0 +1,2 @@
+var supportedLocales = ['de', 'en', 'fr', 'ro']
+var defaultLocale = 'en'

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
     <p class="hint" id="xmppis"></p>
   </div>
   <script src="scripts/i18n-text.min.js"></script>
+  <script src="config.js"></script>
   <script src="scripts/main.js"></script>
   <script src="scripts/qrcode.min.js"></script>
 </body>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -94,7 +94,19 @@
 		i18n.once(I18nText.event.LOCALE_CHANGE, function (data) {
 			rehash();
 		});
-		i18n.setLocale('en');
+
+		var preferredLocale, setLocale = false;
+		for (preferredLocale of navigator.languages) {
+			if (supportedLocales.includes(preferredLocale)) {
+				i18n.setLocale(preferredLocale);
+				setLocale = true;
+				break;
+			}
+		}
+		if (!setLocale) {
+			i18n.setLocale(defaultLocale);
+		}
+
 
 		// functionality
 		if (navigator.userAgent.indexOf("Android") >= 0) {


### PR DESCRIPTION
This change adds the ability to detect the preferred language.
Fallback is a configurable default language.

To run this, `config.js.dist` has to be copied to `config.js` which is ignored by git to not accedently commit custom configs.